### PR TITLE
Uncaught TypeError: Cannot read property 'update' of null #41

### DIFF
--- a/build/phaser-input.js
+++ b/build/phaser-input.js
@@ -311,9 +311,9 @@ var PhaserInput;
         };
         InputField.prototype.update = function () {
             this.text.update();
-			if(this.placeHolder)
+	    if(this.placeHolder)
             this.placeHolder.update();
-			}
+	    }
             if (!this.focus) {
                 return;
             }

--- a/build/phaser-input.js
+++ b/build/phaser-input.js
@@ -311,7 +311,9 @@ var PhaserInput;
         };
         InputField.prototype.update = function () {
             this.text.update();
+			if(this.placeHolder)
             this.placeHolder.update();
+			}
             if (!this.focus) {
                 return;
             }


### PR DESCRIPTION
I am using phaser input and got the error on Uncaught TypeError: Cannot read property 'update' of null ' with this.placeHolder and as on the issue #41 @CFix-Ollie suggested to add a check on this.placeHolder before its called by update and also he gave a commit for the phaser-input.ts file. I faced the same problem in javascript version and  the same solution worked for me too hence I have committed same changes for phaser-input.js. 

i haven't committed any changes to phaser-input.min.js  hence if any one using minified then it still needs to be updated.  