### PR TITLE
Add Browserify support

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,5 +33,6 @@
     "grunt-ts": "^6.0.0-beta.11",
     "phaser": "2.6.2",
     "typescript": "2.3.x"
-  }
+  },
+  "main": "build/phaser-input.min.js"
 }


### PR DESCRIPTION
When loading this module through node or [Browserify's](http://browserify.org/) `require()` a "module not found" error is thrown.
This is due to the package.json file missing a "[main](https://docs.npmjs.com/files/package.json#main)" entry pointing to the main application script.

By adding this Node and Browserify users can easily use `require('@orange-games/phaser-input')`, allowing it to be nicely packaged inside their bundled script file.

Do note that using the script in this way still requires one to expose Phaser to the global scope. This is caused by the plugin relying on globals.