### PR TITLE
Do not use default values if there is a value specified

### DIFF
--- a/ts/Objects/InputBox.ts
+++ b/ts/Objects/InputBox.ts
@@ -13,8 +13,8 @@ module PhaserInput {
             super(game, 0, 0);
             
             this.bgColor = (inputOptions.backgroundColor) ? parseInt(inputOptions.backgroundColor.slice(1), 16) : 0xffffff;
-            this.borderRadius = inputOptions.borderRadius || 0;
-            this.borderWidth = inputOptions.borderWidth || 1;
+            this.borderRadius = inputOptions.borderRadius = (typeof inputOptions.borderRadius === 'number') ? inputOptions.borderRadius : 0;
+            this.borderWidth = inputOptions.borderWidth = (typeof inputOptions.borderWidth === 'number') ? inputOptions.borderWidth : 1;
             this.borderColor = (inputOptions.borderColor) ? parseInt(inputOptions.borderColor.slice(1), 16) : 0x959595;
             this.boxAlpha = inputOptions.fillAlpha;
             this.padding = inputOptions.padding;


### PR DESCRIPTION
This fixes an issue where defaults were being used if the specified value evaluated to false.

Fixes https://github.com/orange-games/phaser-input/issues/68